### PR TITLE
Links in right/left additions now clickable

### DIFF
--- a/CSS/ShapeStyle.css
+++ b/CSS/ShapeStyle.css
@@ -463,6 +463,9 @@ Footer {
     .leftAddition, .rightAddition{;
         z-index: -10;
     }
+        .leftAddition.containsLink, .rightAddition.containsLink {
+            z-index: inherit;
+        }        
 
     .leftAddition{
         position: absolute;

--- a/CSS/ShapeStyle.css
+++ b/CSS/ShapeStyle.css
@@ -463,9 +463,11 @@ Footer {
     .leftAddition, .rightAddition{;
         z-index: -10;
     }
-        .leftAddition.containsLink, .rightAddition.containsLink {
-            z-index: inherit;
-        }        
+    
+    /* Ensures that the links within sidepanels remain clickable */    
+    .leftAddition.containsLink, .rightAddition.containsLink {
+        z-index: inherit;
+    }        
 
     .leftAddition{
         position: absolute;

--- a/HTML/FC_Bezoekers_NL.html
+++ b/HTML/FC_Bezoekers_NL.html
@@ -79,7 +79,7 @@
 
 		<h1>Editie 2020, 7 Juni</h1>
 		<p>
-		We zijn weer volop bezig met de organisatie van de nieuwe editie. Deze zal plaatsvinden op 7 juli 2020. Als je ondertussen meer wilt weten of interesse hebt in deelname aan Fantasycourt 2020. Kijk dan gerust op ons <a href="https://www.facebook.com/events/554879805301177/"> Facebook evenement</a> of stuur ons een <a href="mailto:organisatie@fantasycourt.nl">e-mail</a>.
+		We zijn weer volop bezig met de organisatie van de nieuwe editie. Deze zal plaatsvinden op 7 juni 2020. Als je ondertussen meer wilt weten of interesse hebt in deelname aan Fantasycourt 2020. Kijk dan gerust op ons <a href="https://www.facebook.com/events/554879805301177/"> Facebook evenement</a> of stuur ons een <a href="mailto:organisatie@fantasycourt.nl">e-mail</a>.
 		</p>
 
             <h1>Voorgaande edities</h1>

--- a/HTML/FC_Bezoekers_NL.html
+++ b/HTML/FC_Bezoekers_NL.html
@@ -38,7 +38,7 @@
                 Burgers, boeren, edelen, zegt ten allen voort<br>
                 Jullie zijn allen uitgenodigd aan het hof van Fantasy Court
             </i></h3>
-            <div class="rightAddition">
+            <div class="rightAddition containsLink">
                 <div>
                     <div class="additionInfo rot_-3">
                         <div class="hanger"></div>


### PR DESCRIPTION
The former negative z-index caused the link to be unclickable.

Unfortunately there does not seem to be a way to select elements with a non-empty href <a>-child (you can only select such a child itself), so an extra class was added instead (which is more error-prone).