### PR TITLE
Open Graph (link previews)

### DIFF
--- a/fantasycourt.nl/config.toml
+++ b/fantasycourt.nl/config.toml
@@ -14,7 +14,16 @@ alt = "Fantasy Court Swordfighting Tournament"
 position-x = "50%"
 position-y = "30%"
 
+# Open Graph
+[params.og]
+locale = 'nl_NL' # Hugo's languageCode is in a different format and is not supported by OG
+site-name = "Fantasy Court"
+title = "Fantasy Court"
+description = "Fantasy Court is een fantasy festival dat zich focust op de unieke en niche cultuur rondom fantasy-evenementen en LARP (Live Action Roleplay)."
+image = "/images/icons/Fantasy Court - Logo.png"
+image-alt = "Fantasy Court Logo"
 
+# Languages
 [languages]
 [languages.nl]
 name = "Nederlands"
@@ -43,6 +52,21 @@ weight = 3
 name = "English"
 title = "Fantasy Court"
 weight = 1
+languageCode = "en-gb"
+
+[languages.en.og]
+locale = "en_GB"
+description = "Fantasy Court is a fantasy festival that is focused on the somewhat unique and niche culture that surrounds fantasy events and LARP (Live Action Role Playing)."
+# copy of above
+  # If this is omitted, then hugo uses the empty string for these values.
+  # The docs indicate it should just use the top-level params, but those values aren't
+  #   even avaible in $.Site.Parms in the first place... WHY!?
+  site-name = "Fantasy Court"
+  title = "Fantasy Court"
+  image = "/images/icons/Fantasy Court - Logo.png"
+  image-alt = "Fantasy Court Logo"
+# end copy
+
 
 [[languages.en.menu.main]]
 identifier = "visitors"

--- a/fantasycourt.nl/content/standhouders/_index.en.md
+++ b/fantasycourt.nl/content/standhouders/_index.en.md
@@ -4,6 +4,8 @@ header-image:
   url: images/FC_crew.jpg
   position-x: 50%
   position-y: 50%
+og:
+  description: "In order to make Fantasy Court the best version it could be, we are looking for people who can enrich the experience in their own way. Vendors, acts, workshops, demos, LARP associations, or anything else that fits!"
 ---
 
 {{< message >}}
@@ -53,12 +55,12 @@ Edible products or drinks such as sandwiches, sweet snacks or medieval beverages
 {{< \small >}}
 
 Do you have anything that could fit our festival and got questions? Please do contact us via [standhouders@fantasycourt.nl](mailto:standhouders@fantasycourt.nl) or go to our [Facebook Page](https://www.facebook.com/FantasyCourt/). We'd love to know if you could contribute to our wonderful festival!
-            
+
 <!---
 The subscription for vendors will open soon! Are you already exited to join as a standholder? Sign up via [this](https://goo.gl/forms/iPVDBuA1ef0gqhN63) Goole Form.
 
 -->
-            
+
 ## Practical information
 Fantasy Court 2021 will take place around June 2021 on one of the grass fields on the campus of the Technical Univerisity of Eindhoven. Further information on the exact times will be announced later, though we intend to entertain through most of the afternoon till the early evening.
 
@@ -67,7 +69,7 @@ Compensation for performances and acts can be negotiated with the organisation.
 
 
 {{< message margin-top="80px" margin-bottom="100px">}}
-_See you at the court!_  
+_See you at the court!_
 {{< /message >}}
 
 ## Sponsors

--- a/fantasycourt.nl/content/standhouders/_index.nl.md
+++ b/fantasycourt.nl/content/standhouders/_index.nl.md
@@ -4,6 +4,8 @@ header-image:
   url: images/FC_crew.jpg
   position-x: 50%
   position-y: 50%
+og:
+  description: "Om Fantasy Court de beste versie ooit te kunnen geven zijn we op zoek naar mensen die de ervaring op hun eigen manier kunnen verrijken. Stanhouders, acts, workshops, demo's, LARP-verenigngen, of iets anders dat past!"
 ---
 
 {{< message >}}
@@ -11,20 +13,20 @@ header-image:
   _Uw aanwezigheid is gewenst, met uw waren en uw kunsten_
 {{< /message >}}
 
-# Standhouders Editie 2021              
+# Standhouders Editie 2021
 Om Fantasy Court nog beter te maken zijn wij altijd op zoek naar meer mensen die ons evenement kunnen verrijken!
 Wij bieden jullie een geweldig, enthousiast publiek dat komt voor de sfeer en de gespecialiseerde zaken. Want waar in Nederland vind je nou een festival dat zich vooral met LARP en gerelateerde zaken bezighoudt?
 
 # Standhouders Editie 2020
 Het doet pijn in ons hart, maar helaas hebben wij moeten besluiten om Fantasy Court 2020 af te gelasten. De toenmalige landelijke maatregelen betreffende COVID-19 liepen minimaal tot 1 juni terwijl Fantasy Court op 7 juni zou vallen. Daarbij stonden strengere landelijke maatregelen die later ingingen het ook niet meer toe om in Nederland een festival te organiseren.
 
-De mogelijke tijd van 1 juni tot 7 juni was voor ons te kort om zonder acceptabel menselijk risico, financieel risico, of studievertraging een festival neer te zetten. We hadden overwogen het festival te verschuiven, maar zagen daar geen goede opties die voldoende zekerheid boden voor een geslaagd evenement, goed weer, of tijd tot Fantasy Court 2021. 
+De mogelijke tijd van 1 juni tot 7 juni was voor ons te kort om zonder acceptabel menselijk risico, financieel risico, of studievertraging een festival neer te zetten. We hadden overwogen het festival te verschuiven, maar zagen daar geen goede opties die voldoende zekerheid boden voor een geslaagd evenement, goed weer, of tijd tot Fantasy Court 2021.
 
 Om deze reden hebben wij besloten ons te richten op de volgende editie rond juni 2021. We hopen jullie dan allemaal in goede gezondheid te mogen ontvangen.
 
 ## Wie zoeken wij?
 Wij zijn op zoek naar mensen of bedrijven die het volgende kunnen bieden:
-            
+
 Winkelkramen met benodigdheden, accessoires of zelfs kostuums voor:
 * LARP
 * Rollenspellen
@@ -65,7 +67,7 @@ De kosten voor standhouders zullen bestaan uit een kleine deelnemersbijdrage (â‚
 Over de compensatie voor optredens en acts kan met de organisatie worden onderhandeld.
 
 {{< message margin-top="80px" margin-bottom="100px">}}
-_Tot op het hof!_  
+_Tot op het hof!_
 {{< /message >}}
 
 ## Sponsoren

--- a/fantasycourt.nl/content/standhouders/_index.nl.md
+++ b/fantasycourt.nl/content/standhouders/_index.nl.md
@@ -5,7 +5,7 @@ header-image:
   position-x: 50%
   position-y: 50%
 og:
-  description: "Om Fantasy Court de beste versie ooit te kunnen geven zijn we op zoek naar mensen die de ervaring op hun eigen manier kunnen verrijken. Stanhouders, acts, workshops, demo's, LARP-verenigngen, of iets anders dat past!"
+  description: "Om Fantasy Court de beste versie ooit te kunnen geven zijn we op zoek naar mensen die de ervaring op hun eigen manier kunnen verrijken. Standhouders, acts, workshops, demo's, LARP-verenigingen, of iets anders dat past!"
 ---
 
 {{< message >}}

--- a/fantasycourt.nl/themes/fantasy-court/layouts/partials/head.html
+++ b/fantasycourt.nl/themes/fantasy-court/layouts/partials/head.html
@@ -26,4 +26,20 @@
             }
         }
     </script>
+
+    <!-- Open Graph (for link previews in Discord, Telegram, etc.) -->
+    <meta property="og:title" content='{{ .Param "og.title" }}' />
+    <meta property="og:description" content='{{ .Param "og.description" }}' />
+    <meta property="og:image" content='{{ .Site.BaseURL }}{{ .Param "og.image" }}' />
+    <meta property="og:image:alt" content='{{ .Param "og.image-alt" }}' />
+    <meta property="og:site_name" content="{{ .Site.Title }}" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="{{ .Site.BaseURL }}" />
+    <meta property="og:locale" content='{{ .Param "og.locale" }}' />
+    {{ range .AllTranslations }}
+        <!-- List all language codes except the currently selected language -->
+        {{ if (ne (.Param "og.locale") ($.Param "og.locale") ) }}
+            <meta property="og:locale:alternate" content='{{ .Param "og.locale" }}' />
+        {{end}}
+    {{ end }}
 </head>


### PR DESCRIPTION
Utilise the Open Graph meta tags to allow link previews in external media (such as Telegram or Discord)
https://ogp.me/