### PR TITLE
rsync deletion fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,3 +44,4 @@ jobs:
           REMOTE_HOST: ${{ secrets.DEPLOY_HOST }}
           REMOTE_USER: ${{ secrets.DEPLOY_USER }}
           TARGET: ${{ secrets.DEPLOY_TARGET }}
+          ARGS: "-rlgoDzvc -i --delete"


### PR DESCRIPTION
Pass --delete flag so that files in the destination directory (i.e., the server) that are not in the source directory (i.e., this repo) will be deleted.

The other flags are the action's default.

Change identical to the one in esrg-knights/kotkt-website#55