### PR TITLE
Nav-bar improvements

### DIFF
--- a/fantasycourt.nl/themes/fantasy-court/assets/css/_navbar.scss
+++ b/fantasycourt.nl/themes/fantasy-court/assets/css/_navbar.scss
@@ -25,7 +25,7 @@ nav {
       min-height: $navbarHeight;
     }
     padding: 0 10px;
-    display: block;
+    display: flex;
     
     &:hover {
       background-color: lighten($backgroundColourInverted, 5);

--- a/fantasycourt.nl/themes/fantasy-court/assets/css/_navbar.scss
+++ b/fantasycourt.nl/themes/fantasy-court/assets/css/_navbar.scss
@@ -28,6 +28,7 @@ nav {
     display: flex;
     
     &:hover {
+      color: $textColorInverted;
       background-color: lighten($backgroundColourInverted, 5);
     }
   }

--- a/fantasycourt.nl/themes/fantasy-court/assets/css/_navbar.scss
+++ b/fantasycourt.nl/themes/fantasy-court/assets/css/_navbar.scss
@@ -95,55 +95,50 @@ nav {
 .submenu {
   display: none; /* Hide submenus by default */
   position: relative; /* Make submenu position absolute */
-  top: 0; /* Position the submenu directly below the parent link */
-  left: 0; /* Align submenu with the left edge of the parent <a> */
-  background-color: $backgroundColourInverted; /* Same as the main navigation background */
-  z-index: 1000;
 
   min-height: $mobileNavbarHeight;
   @media screen and (min-width: $containerWidth) {
     // Non-mobile display
     min-height: $navbarHeight;
   }
-}
 
-/* Style for submenu links */
-.submenu a {
-  width: 100%;
-  color: $textColorInverted;
-  background-color: $backgroundColourInverted;
-}
-
-.submenu a:hover {
-  background-color: lighten($backgroundColourInverted, 5%);
-}
-
-/* Show submenu on hover (desktop) */
-nav a:hover + .submenu {
-  display: block; /* Show submenu when parent <a> is hovered */
-}
-
-/* Mobile handling - hide submenu by default */
-@media screen and (max-width: $containerWidth) {
-  .submenu {
-    display: none; /* Hide submenus by default on mobile */
+  .is-active {
+    background-color: lighten($backgroundColourInverted, 10);
+    border-bottom: 3px solid $borderColour;
   }
 
-  /* Show submenu when parent link is clicked */
-  a.active + .submenu {
-    display: block;
+  a {
+    width: 100%;
+    color: $textColorInverted;
+    background-color: $backgroundColourInverted;
   }
 }
 
-/* Optional: Mobile toggle menu styles */
-nav.responsive .submenu {
-  display: block; /* Ensure submenus are visible in responsive mode */
+.verticalLine {
+  width: 2px;
+  background-color: $textColorInverted;
+  margin: 0.25 * $navbarHeight;
+  height: 50%;
+  display: block;
+  @media screen and (max-width: $containerWidth) {
+    display: none;
+  }
 }
 
 /*
   The "responsive" class is added to the topnav with JavaScript when the user clicks on the hamburger icon.
   This class makes the navigation visible on mobile devices (where it would otherwise be hidden)
 */
-nav.responsive a {
-  display: flex;
+nav.responsive{
+  a {
+    display: flex;
+  }
+
+  .submenu {
+    display: flex;
+    a {
+      font-size:medium;
+      padding-left: 5%;
+    }
+  }
 }

--- a/fantasycourt.nl/themes/fantasy-court/assets/css/_navbar.scss
+++ b/fantasycourt.nl/themes/fantasy-court/assets/css/_navbar.scss
@@ -20,8 +20,13 @@ nav {
 
   a {
     min-height: $mobileNavbarHeight;
+    @media screen and (min-width: $containerWidth) {
+      // Non-mobile display
+      min-height: $navbarHeight;
+    }
     padding: 0 10px;
-
+    display: block;
+    
     &:hover {
       background-color: lighten($backgroundColourInverted, 5);
     }
@@ -59,7 +64,6 @@ nav {
   }
 
   * {
-    display: flex;
     flex-direction: column;
     justify-content: center;
     font-size: larger;
@@ -72,6 +76,7 @@ nav {
   }
 
   #languagebox {
+    display: flex;
     flex-direction: row;
   }
 
@@ -79,6 +84,59 @@ nav {
     background-color: lighten($backgroundColourInverted, 10);
     border-bottom: 3px solid $borderColour;
   }
+}
+
+.nav-item:hover .submenu{
+  display: flex;
+}
+
+/* Style for submenu */
+.submenu {
+  display: none; /* Hide submenus by default */
+  position: relative; /* Make submenu position absolute */
+  top: 0; /* Position the submenu directly below the parent link */
+  left: 0; /* Align submenu with the left edge of the parent <a> */
+  background-color: $backgroundColourInverted; /* Same as the main navigation background */
+  z-index: 1000;
+
+  min-height: $mobileNavbarHeight;
+  @media screen and (min-width: $containerWidth) {
+    // Non-mobile display
+    min-height: $navbarHeight;
+  }
+}
+
+/* Style for submenu links */
+.submenu a {
+  width: 100%;
+  color: $textColorInverted;
+  background-color: $backgroundColourInverted;
+}
+
+.submenu a:hover {
+  background-color: lighten($backgroundColourInverted, 5%);
+}
+
+/* Show submenu on hover (desktop) */
+nav a:hover + .submenu {
+  display: block; /* Show submenu when parent <a> is hovered */
+}
+
+/* Mobile handling - hide submenu by default */
+@media screen and (max-width: $containerWidth) {
+  .submenu {
+    display: none; /* Hide submenus by default on mobile */
+  }
+
+  /* Show submenu when parent link is clicked */
+  a.active + .submenu {
+    display: block;
+  }
+}
+
+/* Optional: Mobile toggle menu styles */
+nav.responsive .submenu {
+  display: block; /* Ensure submenus are visible in responsive mode */
 }
 
 /*

--- a/fantasycourt.nl/themes/fantasy-court/layouts/partials/navbar.html
+++ b/fantasycourt.nl/themes/fantasy-court/layouts/partials/navbar.html
@@ -11,8 +11,18 @@
         <!-- Navigation -->
         {{- $currentPage := . -}}
         {{ range .Site.Menus.main -}}
+        <div class ="nav-item">
         <a href="{{ .URL | relLangURL }}"
         class='{{ if (eq $currentPage.RelPermalink (.URL | relLangURL)) }}is-active{{end}}'>{{.Title}}</a>
+        {{ with .Children }}
+                <div class="submenu">
+                    {{ range . }}
+                    <a href="{{ .URL | relLangURL }}"
+                    class='{{ if (eq $currentPage.RelPermalink (.URL | relLangURL)) }}is-active{{end}}'>{{ .Title }}</a>
+                    {{ end }}
+                </div>
+            {{ end }}
+        </div>
         {{- end }}
 
         <p class="hide-on-mobile">|</p>

--- a/fantasycourt.nl/themes/fantasy-court/layouts/partials/navbar.html
+++ b/fantasycourt.nl/themes/fantasy-court/layouts/partials/navbar.html
@@ -25,7 +25,8 @@
         </div>
         {{- end }}
 
-        <p class="hide-on-mobile">|</p>
+        <div class="verticalLine">
+        </div>
 
         <!-- Language Options -->
         <div id="languagebox">


### PR DESCRIPTION
# Improvements
1. The navbar now supports dropdown menu's. When adding a new page, add a parent tag in config.toml containing the identifier for the menu you want to drop it down from. e.g. 
[[languages.en.menu.main]]
identifier = "route"
parent = "practical"
title = "Route from station"
url = "/proktische_info/route/"
weight = 1

2. The name of the pages no longer turn blue when hovering over them
3. The en and nl buttons now use the full height of the navbar for consistency
4. The vertical line between the navigation buttons and language options is now taller and vertically centered

# Potential issues
1. The dropdown menu is kinda funky when then sub menu name is longer than the main menu name
2. In mobile mode all sub menu's are always shown. Their names are smaller and slightly set to the right. Might be an issue if we have many sub menu's as menu is not scrollable atm.